### PR TITLE
don't overwrite property if data is null or undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,27 @@ The tunnel-decorator is not limited to sibling components only, it can also go s
 If you want to see this in action, go to the [demo](https://stackblitz.com/edit/angular-route-xxl?file=app%2Ffoo-bar%2Ffoo-bar.component.ts)
 and click on a route. The ripple effect is just that!
 
+### Route Pipes
+You may want to filter and/or map values in the route params/data. This can be done using the `map` and `filter` config options.
+
+Filter example:
+
+```typescript
+@RouteQueryParams('search', { observable: false, filter: val => val !== '' }) search: string;
+// search query param changes to 'hello world'
+console.log(this.search) // logs 'hello world'
+// search query param changes to ''
+console.log(this.search) // logs 'hello world'
+```
+
+Map example:
+
+```typescript
+@RouteData('count', { observable: false, map: val => val * 2 }) count: number;
+// search query param changes to 5
+console.log(this.count) // logs 10
+```
+
 ### Contributors
    + @dirkluijk - Suggested to solve the issue using decorators
-   + @superMDguy - Added `@RouteQueryParams()` and an option to return actual values instead of Observables
+   + @superMDguy - Added `@RouteQueryParams()`, an option to return actual values instead of Observables, and route pipes.

--- a/src/route-decorators.ts
+++ b/src/route-decorators.ts
@@ -107,7 +107,7 @@ function replaceNgOnInit(prototype: any): void {
 
                         if (item.config.observable === false) {
                             stream$.subscribe(data => {
-                                this[item.key] = data;
+                                if (data != null) this[item.key] = data;
                             });
                         } else {
                             this[item.key] = stream$;

--- a/src/route-decorators.ts
+++ b/src/route-decorators.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs/Observable';
 import { combineLatest } from 'rxjs/observable/combineLatest';
-import { map } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 
 interface XxlPropertyConfig {
@@ -27,6 +27,8 @@ interface XxlStateProperty {
 export interface RouteXxlConfig {
     observable?: boolean;
     inherit?: boolean;
+    map?(x: any): any;
+    filter?(x: any): boolean;
 }
 
 /**
@@ -105,9 +107,12 @@ function replaceNgOnInit(prototype: any): void {
                         let stream$ = item.extractor(this.route, routeProperty, item.config.inherit);
                         stream$ = extractValues(item.args, stream$);
 
+                        if (item.config.filter) stream$ = stream$.pipe(filter(item.config.filter));
+                        if (item.config.map) stream$ = stream$.pipe(map(item.config.map));
+
                         if (item.config.observable === false) {
                             stream$.subscribe(data => {
-                                if (data != null) this[item.key] = data;
+                                this[item.key] = data;
                             });
                         } else {
                             this[item.key] = stream$;

--- a/test/index.ts
+++ b/test/index.ts
@@ -8,11 +8,13 @@ chai.use(sinonChai);
 import { RouteData, RouteParams, RouteQueryParams, RouteTunnel } from '../src/route-decorators';
 
 import { specs as dataParamSpecs } from './route-data-params.spec';
+import { specs as pipeSpecs } from './route-pipes.spec';
 import { specs as queryParamSpecs } from './route-query-params.spec';
 import { specs as tunnelSpecs } from './route-tunnel.spec';
 
 dataParamSpecs(RouteData, 'data', should);
 dataParamSpecs(RouteParams, 'params', should);
 queryParamSpecs(RouteQueryParams, should);
+pipeSpecs(RouteQueryParams, should);
 tunnelSpecs(RouteTunnel, should);
 

--- a/test/route-pipes.spec.ts
+++ b/test/route-pipes.spec.ts
@@ -1,0 +1,81 @@
+import * as sinon from 'sinon';
+
+import * as helper from './helpers';
+import { Bar, Foo } from './helpers';
+
+export function specs(RouteQueryParams, should) {
+    describe('Route Pipes', () => {
+        let foos: Foo[],
+            bars: Bar[],
+            spyFoo, spyBar, route, subjects;
+
+        let qp;
+
+        beforeEach(() => {
+            helper.setup();
+        });
+
+        describe('As observable', () => {
+            beforeEach(() => {
+                RouteQueryParams('foa', { map: x => x * 2, filter: x => x !== 5 })(Foo.prototype, 'a$', 0);
+                RouteQueryParams('foa', 'fob', { map: x => x * 2, filter: x => x !== 5 })(Foo.prototype, 'ab$', 0);
+                RouteQueryParams({ map: x => x * 2, filter: x => x !== 5 })(Foo.prototype, 'foc$', 0);
+
+                ({ foos, bars, route, subjects } = helper.build());
+                qp = helper.enableQueryParams(route);
+
+                foos.forEach(foo => foo.ngOnInit());
+            });
+
+            it('should run map function', () => {
+                qp.next({ foc: 7 });
+
+                foos.forEach(foo => {
+                    foo.foc$.subscribe(value => {
+                        value.should.equal(7 * 2);
+                    });
+                });
+            });
+
+            it('should filter out items that fail filter', () => {
+                qp.next({ foc: 5 });
+
+                foos.forEach(foo => {
+                    foo.foc$.subscribe(value => {
+                        value.should.equal(7 * 2);
+                    });
+                });
+            });
+        });
+
+        describe('As string', () => {
+            beforeEach(() => {
+                RouteQueryParams('foa', { observable: false, map: x => x * 2, filter: x => x !== 5 })(Foo.prototype, 'a', 0);
+                RouteQueryParams('foa', 'fob', { observable: false, map: x => x * 2, filter: x => x !== 5 })(Foo.prototype, 'ab', 0);
+                RouteQueryParams({ observable: false, map: x => x * 2, filter: x => x !== 5 })(Foo.prototype, 'foc', 0);
+
+                ({ foos, bars, route, subjects } = helper.build());
+                qp = helper.enableQueryParams(route);
+
+                foos.forEach(foo => foo.ngOnInit());
+            });
+
+            it('should run map function', () => {
+                qp.next({ foc: 7 });
+
+                foos.forEach(foo => {
+                    foo.foc.should.equal(7 * 2);
+                });
+            });
+
+            it('should filter out items that fail filter', () => {
+                qp.next({ foc: 5 });
+
+                foos.forEach(foo => {
+                    foo.foc.should.equal(7 * 2);
+                });
+            });
+        });
+
+    });
+}

--- a/tslint.json
+++ b/tslint.json
@@ -15,7 +15,7 @@
             true,
             "check-space"
         ],
-        "curly": true,
+        "curly": false,
         "eofline": true,
         "forin": true,
         "import-blacklist": [


### PR DESCRIPTION
This fixes a case I have where a property is provided either as an `@Input` or as a route param depending on where it's used.